### PR TITLE
fix: handle UTF-8 character boundaries in cell truncation

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -4,7 +4,8 @@ use prettytable::{Cell, Row, Table, format};
 
 /// Format a cell value with width limiting
 fn format_cell_value(value: &str, max_width: usize, wrap: bool) -> String {
-    if value.len() <= max_width {
+    let char_count = value.chars().count();
+    if char_count <= max_width {
         return value.to_string();
     }
 
@@ -13,16 +14,18 @@ fn format_cell_value(value: &str, max_width: usize, wrap: bool) -> String {
         // We'll truncate with a note. Full wrapping would require custom rendering.
         // Future: implement multi-line cell support
         if max_width > 3 {
-            format!("{}...", &value[..max_width - 3])
+            let truncated: String = value.chars().take(max_width - 3).collect();
+            format!("{}...", truncated)
         } else {
-            value[..max_width].to_string()
+            value.chars().take(max_width).collect()
         }
     } else {
         // Truncate with "..."
         if max_width > 3 {
-            format!("{}...", &value[..max_width - 3])
+            let truncated: String = value.chars().take(max_width - 3).collect();
+            format!("{}...", truncated)
         } else {
-            value[..max_width].to_string()
+            value.chars().take(max_width).collect()
         }
     }
 }


### PR DESCRIPTION
Fixes #11 - Panic when displaying cells with multi-byte UTF-8 characters (German umlauts, special symbols like §, etc.) in table mode.

Previously used byte-based string slicing which could cut through multi-byte characters. Now uses char-based iteration to respect character boundaries.

Changes:
- Use .chars().count() for length check instead of .len()
- Use .chars().take(n).collect() for truncation instead of &str[..n]
- Applies to both wrapped and non-wrapped cell formatting

Tested with German umlauts (Ü, §) - no longer panics. JSON export and TUI mode already worked correctly.