### PR TITLE
fix vim key binding

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -220,27 +220,30 @@ fn parse_key_string(s: &str) -> Option<(KeyCode, KeyModifiers)> {
         }
     }
 
-    // Parse key code
-    let code = match key_part.to_lowercase().as_str() {
-        "enter" => KeyCode::Enter,
-        "esc" | "escape" => KeyCode::Esc,
-        "tab" => KeyCode::Tab,
-        "backtab" => KeyCode::BackTab,
-        "backspace" => KeyCode::Backspace,
-        "delete" | "del" => KeyCode::Delete,
-        "insert" | "ins" => KeyCode::Insert,
-        "home" => KeyCode::Home,
-        "end" => KeyCode::End,
-        "pageup" | "pgup" => KeyCode::PageUp,
-        "pagedown" | "pgdn" => KeyCode::PageDown,
-        "up" => KeyCode::Up,
-        "down" => KeyCode::Down,
-        "left" => KeyCode::Left,
-        "right" => KeyCode::Right,
+    let code = match *key_part {
+        k if k.eq_ignore_ascii_case("enter") => KeyCode::Enter,
+        k if k.eq_ignore_ascii_case("esc") => KeyCode::Esc,
+        k if k.eq_ignore_ascii_case("escape") => KeyCode::Esc,
+        k if k.eq_ignore_ascii_case("tab") => KeyCode::Tab,
+        k if k.eq_ignore_ascii_case("backtab") => KeyCode::BackTab,
+        k if k.eq_ignore_ascii_case("backspace") => KeyCode::Backspace,
+        k if k.eq_ignore_ascii_case("delete") => KeyCode::Delete,
+        k if k.eq_ignore_ascii_case("del") => KeyCode::Delete,
+        k if k.eq_ignore_ascii_case("insert") => KeyCode::Insert,
+        k if k.eq_ignore_ascii_case("ins") => KeyCode::Insert,
+        k if k.eq_ignore_ascii_case("home") => KeyCode::Home,
+        k if k.eq_ignore_ascii_case("end") => KeyCode::End,
+        k if k.eq_ignore_ascii_case("pageup") => KeyCode::PageUp,
+        k if k.eq_ignore_ascii_case("pgup") => KeyCode::PageUp,
+        k if k.eq_ignore_ascii_case("pagedown") => KeyCode::PageDown,
+        k if k.eq_ignore_ascii_case("pgdn") => KeyCode::PageDown,
+        k if k.eq_ignore_ascii_case("up") => KeyCode::Up,
+        k if k.eq_ignore_ascii_case("down") => KeyCode::Down,
+        k if k.eq_ignore_ascii_case("left") => KeyCode::Left,
+        k if k.eq_ignore_ascii_case("right") => KeyCode::Right,
         s if s.len() == 1 => KeyCode::Char(s.chars().next()?),
         _ => return None,
     };
-
     Some((code, modifiers))
 }
 
@@ -288,7 +291,7 @@ fn get_vim_keybinding(action: &str) -> Option<(KeyCode, KeyModifiers)> {
         "jump_to_top" => ("g", KeyModifiers::empty()),
         "jump_to_bottom" => ("G", KeyModifiers::SHIFT),
         "jump_to_row_start" => ("0", KeyModifiers::empty()),
-        "jump_to_row_end" => ("$", KeyModifiers::SHIFT),
+        "jump_to_row_end" => ("$", KeyModifiers::empty()),
         // VIM-style actions
         "quit" => ("q", KeyModifiers::empty()),
         "copy_cell" => ("y", KeyModifiers::empty()),


### PR DESCRIPTION
Vim key binding not working when press Shift + G or $

Fix by removing to lower case key code