### PR TITLE
Add directory change before installation in publish-aur.yml

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -75,6 +75,7 @@ jobs:
           sha256sums=("SHA256_PLACEHOLDER")
 
           package() {
+              cd "$srcdir/xleak-x86_64-unknown-linux-gnu"
               install -Dm755 xleak -t "$pkgdir/usr/bin"
               install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
           }


### PR DESCRIPTION
Small fix for AUR package installation, it was failing for me because sources are located inside the folder, added change directory command and then install commands. 
Testing:
yay -G xleak-bin
Added this line to PKBBUILD
then ran makepkg -si
This way i could install xleak-bin package while automatic installation from aur using yay failed