### PR TITLE
fix: migrate terminal output to comfy-table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm 0.29.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +330,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.2",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,27 +357,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "darling"
@@ -410,16 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,17 +423,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -464,16 +447,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -619,12 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,17 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,12 +712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +738,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -987,20 +956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,7 +1007,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools",
@@ -1271,17 +1226,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -1815,9 +1759,9 @@ dependencies = [
  "calamine",
  "chrono",
  "clap",
- "crossterm",
+ "comfy-table",
+ "crossterm 0.28.1",
  "dirs",
- "prettytable-rs",
  "ratatui",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 calamine = "0.26"
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
-prettytable-rs = "0.10"
+comfy-table = "7.1"
 
 # TUI dependencies
 ratatui = "0.29"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,8 @@
 use crate::workbook::{CellValue, SheetData};
 use anyhow::Result;
-use prettytable::{Cell, Row, Table, format};
+use comfy_table::{
+    Attribute, Cell, CellAlignment, ColumnConstraint, ContentArrangement, Row, Table, Width,
+};
 
 /// Format a cell value with width limiting
 fn format_cell_value(value: &str, max_width: usize, wrap: bool) -> String {
@@ -10,15 +12,8 @@ fn format_cell_value(value: &str, max_width: usize, wrap: bool) -> String {
     }
 
     if wrap {
-        // For now, wrapping is not fully implemented with prettytable
-        // We'll truncate with a note. Full wrapping would require custom rendering.
-        // Future: implement multi-line cell support
-        if max_width > 3 {
-            let truncated: String = value.chars().take(max_width - 3).collect();
-            format!("{}...", truncated)
-        } else {
-            value.chars().take(max_width).collect()
-        }
+        // Return full text; comfy-table handles the multi-line wrap based on column width
+        value.to_string()
     } else {
         // Truncate with "..."
         if max_width > 3 {
@@ -60,20 +55,25 @@ pub fn display_table(
         return Ok(());
     }
 
-    // Create table
     let mut table = Table::new();
-    table.set_format(*format::consts::FORMAT_BOX_CHARS);
+    if wrap {
+        let width = (data.width as u16)
+            .saturating_mul(max_width as u16 + 3)
+            .max(max_width as u16);
+        table
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_width(width);
+    }
 
-    // Add headers (with width limiting)
-    let header_cells: Vec<Cell> = data
-        .headers
-        .iter()
-        .map(|h| {
-            let formatted = format_cell_value(h, max_width, wrap);
-            Cell::new(&formatted).style_spec("Fgbc")
-        })
-        .collect();
-    table.set_titles(Row::new(header_cells));
+    let mut header_row = Row::new();
+    for h in &data.headers {
+        let formatted = format_cell_value(h, max_width, wrap);
+        header_row.add_cell(Cell::new(formatted).add_attribute(Attribute::Bold));
+    }
+    table.set_header(header_row);
+    table.set_constraints(
+        (0..data.width).map(|_| ColumnConstraint::UpperBoundary(Width::Fixed(max_width as u16))),
+    );
 
     // Add data rows (limit if needed)
     let rows_to_show = if max_rows == 0 {
@@ -83,48 +83,41 @@ pub fn display_table(
     };
 
     for (row_idx, row) in data.rows.iter().enumerate().take(rows_to_show) {
-        let cells: Vec<Cell> = row
-            .iter()
-            .enumerate()
-            .map(|(col_idx, cell)| {
-                // Get formula if it exists and show_formulas is true
-                let value = if show_formulas {
-                    data.formulas
-                        .get(row_idx)
-                        .and_then(|formula_row| formula_row.get(col_idx))
-                        .and_then(|f| f.as_ref())
-                        .cloned()
-                        .unwrap_or_else(|| cell.to_string())
-                } else {
-                    cell.to_string()
-                };
+        let mut table_row = Row::new();
+        for (col_idx, cell) in row.iter().enumerate() {
+            let value = if show_formulas {
+                data.formulas
+                    .get(row_idx)
+                    .and_then(|formula_row| formula_row.get(col_idx))
+                    .and_then(|f| f.as_ref())
+                    .cloned()
+                    .unwrap_or_else(|| cell.to_string())
+            } else {
+                cell.to_string()
+            };
 
-                let formatted = format_cell_value(&value, max_width, wrap);
-                let cell_obj = Cell::new(&formatted);
+            let formatted = format_cell_value(&value, max_width, wrap);
+            let mut cell_obj = Cell::new(formatted);
 
-                // Style based on type (only when not showing formulas)
-                if show_formulas {
-                    cell_obj.style_spec("Fg") // Green for formulas
-                } else {
-                    match cell {
-                        CellValue::Int(_) | CellValue::Float(_) => {
-                            cell_obj.style_spec("Fr") // Right-aligned numbers
-                        }
-                        CellValue::Bool(_) => {
-                            cell_obj.style_spec("Fc") // Centered booleans
-                        }
-                        CellValue::Error(_) => {
-                            cell_obj.style_spec("Frc") // Red errors, centered
-                        }
-                        _ => cell_obj,
+            // Alignment mapping
+            if !show_formulas {
+                cell_obj = match cell {
+                    CellValue::Int(_) | CellValue::Float(_) => {
+                        cell_obj.set_alignment(CellAlignment::Right)
                     }
-                }
-            })
-            .collect();
-        table.add_row(Row::new(cells));
+                    CellValue::Bool(_) => cell_obj.set_alignment(CellAlignment::Center),
+                    CellValue::Error(_) => cell_obj.set_alignment(CellAlignment::Center),
+                    _ => cell_obj.set_alignment(CellAlignment::Left),
+                };
+            } else {
+                cell_obj = cell_obj.set_alignment(CellAlignment::Left);
+            }
+            table_row.add_cell(cell_obj);
+        }
+        table.add_row(table_row);
     }
 
-    table.printstd();
+    println!("{}", table);
 
     // Show row count summary
     println!();
@@ -153,7 +146,6 @@ pub fn export_csv(data: &SheetData) -> Result<()> {
             .iter()
             .map(|cell| {
                 let val = cell.to_string();
-                // Quote if contains comma or quotes
                 if val.contains(',') || val.contains('"') {
                     format!("\"{}\"", val.replace('"', "\"\""))
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
+use comfy_table::{Cell, CellAlignment, ColumnConstraint, ContentArrangement, Row, Table, Width};
 use std::path::PathBuf;
 
 mod config;
@@ -204,9 +205,6 @@ fn main() -> Result<()> {
 
 /// Display table data in terminal (default behavior)
 fn display_table_data(table: &workbook::TableData, max_rows: usize) -> Result<()> {
-    use prettytable::{Cell, Row, Table, format};
-
-    // Print header info
     println!("\n╔═════════════════════════════════════════════════╗");
     println!("║  xleak - Excel Table Viewer                     ║");
     println!("╚═════════════════════════════════════════════════╝");
@@ -219,19 +217,24 @@ fn display_table_data(table: &workbook::TableData, max_rows: usize) -> Result<()
     );
     println!();
 
-    // Create prettytable
-    let mut pt = Table::new();
-    pt.set_format(*format::consts::FORMAT_BOX_CHARS);
+    let max_width = 30u16;
+    let mut table_obj = Table::new();
+    table_obj.set_content_arrangement(ContentArrangement::Dynamic);
+    table_obj.set_width(
+        (table.headers.len() as u16)
+            .saturating_mul(max_width + 3)
+            .max(max_width),
+    );
 
-    // Add headers
-    let header_cells: Vec<Cell> = table
-        .headers
-        .iter()
-        .map(|h| Cell::new(h).style_spec("Fgbc"))
-        .collect();
-    pt.set_titles(Row::new(header_cells));
+    let mut header_row = Row::new();
+    for h in &table.headers {
+        header_row.add_cell(Cell::new(h).add_attribute(comfy_table::Attribute::Bold));
+    }
+    table_obj.set_header(header_row);
+    table_obj.set_constraints(
+        (0..table.headers.len()).map(|_| ColumnConstraint::UpperBoundary(Width::Fixed(max_width))),
+    );
 
-    // Add data rows (limit if needed)
     let rows_to_show = if max_rows == 0 {
         table.rows.len()
     } else {
@@ -239,31 +242,24 @@ fn display_table_data(table: &workbook::TableData, max_rows: usize) -> Result<()
     };
 
     for row in table.rows.iter().take(rows_to_show) {
-        let cells: Vec<Cell> = row
-            .iter()
-            .map(|cell| {
-                let cell_obj = Cell::new(&cell.to_string());
-                // Style based on type
-                match cell {
-                    workbook::CellValue::Int(_) | workbook::CellValue::Float(_) => {
-                        cell_obj.style_spec("Fr") // Right-aligned numbers
-                    }
-                    workbook::CellValue::Bool(_) => {
-                        cell_obj.style_spec("Fc") // Centered booleans
-                    }
-                    workbook::CellValue::Error(_) => {
-                        cell_obj.style_spec("Frc") // Red errors, centered
-                    }
-                    _ => cell_obj,
+        let mut table_row = Row::new();
+        for cell in row {
+            let cell_obj = match cell {
+                workbook::CellValue::Int(_) | workbook::CellValue::Float(_) => {
+                    Cell::new(cell.to_string()).set_alignment(CellAlignment::Right)
                 }
-            })
-            .collect();
-        pt.add_row(Row::new(cells));
+                workbook::CellValue::Bool(_) | workbook::CellValue::Error(_) => {
+                    Cell::new(cell.to_string()).set_alignment(CellAlignment::Center)
+                }
+                _ => Cell::new(cell.to_string()).set_alignment(CellAlignment::Left),
+            };
+            table_row.add_cell(cell_obj);
+        }
+        table_obj.add_row(table_row);
     }
 
-    pt.printstd();
+    println!("{}", table_obj);
 
-    // Show row count summary
     println!();
     if rows_to_show < table.rows.len() {
         println!(


### PR DESCRIPTION
## Purpose

Replace `prettytable-rs` terminal rendering with `comfy-table` so non-interactive output can correctly render wrapped multiline cells and long no-newline content.

## Solution

- Remove `prettytable-rs` dependency and use `comfy-table`.
- Keep existing truncation behavior when `--wrap` is not set.
- Use `ContentArrangement::Dynamic` and column upper-bound constraints when `--wrap` is set.
- Preserve type-based alignment:
  - numbers: right
  - bool/errors: center
  - text/formulas: left
- Migrate `--table` display path in `main.rs`, which still had leftover `prettytable` calls.

## Benchmark results

Release binaries built from isolated worktrees:

- prettytable baseline: `a07bd4c`
- comfy-table branch: `9340569`

Times are wall-clock process time, stdout ignored. Each case includes workbook parsing + table rendering + output formatting.

| Case | Command | Runs | pretty mean ms | comfy mean ms | Delta | Speedup |
|---|---|---:|---:|---:|---:|---:|
| Large default | `xleak tests/fixtures/test_large.xlsx` | 20 | 107.55 | 113.36 | +5.40% | 0.95x |
| Large all rows | `xleak tests/fixtures/test_large.xlsx -n 0` | 5 | 200.14 | 196.05 | -2.04% | 1.02x |
| Long no-newline, no wrap | `xleak tests/fixtures/test_comprehensive.xlsx --sheet EdgeCases` | 20 | 5.62 | 5.75 | +2.24% | 0.98x |
| Long no-newline, wrap | `xleak tests/fixtures/test_comprehensive.xlsx --sheet EdgeCases --wrap` | 20 | 6.20 | 5.91 | -4.75% | 1.05x |
| Multiline wrap | `xleak tests/fixtures/test_comprehensive.xlsx --sheet MultilineCells --wrap` | 20 | 5.38 | 5.95 | +10.58% | 0.90x |

Interpretation: performance is roughly neutral. Small-fixture deltas are sub-millisecond and likely within process/file parsing noise. Migration mainly improves wrapping correctness.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (38 passed)
- [x] `MultilineCells --wrap` shows full multiline cells
- [x] `MultilineCells` without `--wrap` truncates with `...`
