### PR TITLE
fix: detect short extensionless UTF-8 CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV export did not quote the header row ([#52](https://github.com/bgreenwell/xleak/issues/52))
 - JSON export produced invalid JSON for quotes, backslashes, newlines, and non-finite floats ([#53](https://github.com/bgreenwell/xleak/issues/53))
 - TUI search skipped most rows on lazy-loaded sheets (>1000 rows) ([#51](https://github.com/bgreenwell/xleak/issues/51))
+- Extensionless UTF-8 and short CSV files are now detected by content
 - Help popup (`?`) is now scrollable (↑↓/PageUp/PageDown/Home) so it stays usable on short terminals; the title shows a `[x/y]` scroll indicator
 - `display_table_data` now respects `--max-width` CLI flag instead of hardcoded 30
 - Display corruption when switching sheets in interactive mode (removed `eprintln!` writes during raw mode)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,26 +33,21 @@ pub fn detect_file_type<P: AsRef<Path>>(path: P) -> io::Result<FileType> {
 
     // Read the first 8 bytes (covers both the ZIP and OLE2 magic-number lengths).
     let n = file.read(&mut buffer)?;
-
-    // Too short to identify by magic number.
-    if n < 8 {
-        return Ok(FileType::Unknown);
-    }
+    let bytes = &buffer[..n];
 
     // XLSX/ZIP magic number (PK..)
-    if buffer[..4] == [0x50, 0x4B, 0x03, 0x04] {
+    if bytes.len() >= 4 && bytes[..4] == [0x50, 0x4B, 0x03, 0x04] {
         return Ok(FileType::Xlsx);
     }
 
     // XLS (OLE2/CFB) magic number (D0 CF 11 E0 A1 B1 1A E1)
-    if buffer == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
+    if bytes == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
         return Ok(FileType::Xls);
     }
 
     // CSV is plain text with no dedicated magic number, so fall back to a
-    // heuristic: if the first 8 bytes contain no NUL (0x00) and are all ASCII,
-    // treat the file as CSV-like.
-    if buffer.iter().all(|&b| b != 0x00 && b.is_ascii()) {
+    // heuristic: valid UTF-8 without NUL bytes is CSV-like.
+    if !bytes.contains(&0x00) && std::str::from_utf8(bytes).is_ok() {
         return Ok(FileType::Csv);
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -100,6 +100,40 @@ fn test_csv_file_displayed() {
 }
 
 #[test]
+fn test_extensionless_utf8_csv_displayed() {
+    let csv_path = std::env::temp_dir().join("xleak_test_utf8_no_extension");
+    std::fs::write(&csv_path, "\u{feff}City,Temperature\nMünchen,18\n").unwrap();
+
+    let result = run_xleak(&[csv_path.to_str().unwrap()]);
+    let _ = std::fs::remove_file(&csv_path);
+
+    assert!(
+        result.status.success(),
+        "Extensionless UTF-8 CSV failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(String::from_utf8_lossy(&result.stdout).contains("München"));
+}
+
+#[test]
+fn test_short_extensionless_csv_displayed() {
+    let csv_path = std::env::temp_dir().join("xleak_test_short_no_extension");
+    std::fs::write(&csv_path, "a,b\n1,2").unwrap();
+
+    let result = run_xleak(&[csv_path.to_str().unwrap()]);
+    let _ = std::fs::remove_file(&csv_path);
+
+    assert!(
+        result.status.success(),
+        "Short extensionless CSV failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(stdout.contains("a"));
+    assert!(stdout.contains("2"));
+}
+
+#[test]
 fn test_csv_no_header_generates_columns() {
     let tmpdir = std::env::temp_dir();
     let csv_path = tmpdir.join("xleak_test_noheader.csv");


### PR DESCRIPTION
## Summary

- detect extensionless CSV content from the bytes actually read
- accept short and UTF-8 text while keeping ZIP and OLE magic checks length-gated
- cover BOM-prefixed and sub-eight-byte CSVs through the CLI

## Why

The eight-byte ASCII-only fallback rejects valid extensionless CSV files when they are short or start with UTF-8 content.

Fixes #56.

## Validation

- `cargo test --verbose`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --release`