### PR TITLE
fix: detect UTF-8 csv files without extensions

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,25 +34,21 @@ pub fn detect_file_type<P: AsRef<Path>>(path: P) -> io::Result<FileType> {
     // Read the first 8 bytes (covers both the ZIP and OLE2 magic-number lengths).
     let n = file.read(&mut buffer)?;
 
-    // Too short to identify by magic number.
-    if n < 8 {
-        return Ok(FileType::Unknown);
-    }
-
     // XLSX/ZIP magic number (PK..)
-    if buffer[..4] == [0x50, 0x4B, 0x03, 0x04] {
+    if n >= 4 && buffer[..4] == [0x50, 0x4B, 0x03, 0x04] {
         return Ok(FileType::Xlsx);
     }
 
     // XLS (OLE2/CFB) magic number (D0 CF 11 E0 A1 B1 1A E1)
-    if buffer == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
+    if n >= 8 && buffer == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
         return Ok(FileType::Xls);
     }
 
     // CSV is plain text with no dedicated magic number, so fall back to a
-    // heuristic: if the first 8 bytes contain no NUL (0x00) and are all ASCII,
+    // heuristic: if the bytes we read contain no NULs and are valid UTF-8,
     // treat the file as CSV-like.
-    if buffer.iter().all(|&b| b != 0x00 && b.is_ascii()) {
+    let prefix = &buffer[..n];
+    if prefix.iter().all(|&b| b != 0x00) && std::str::from_utf8(prefix).is_ok() {
         return Ok(FileType::Csv);
     }
 
@@ -75,6 +71,16 @@ pub fn column_index_to_letters(col: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("xleak_{name}_{nonce}"))
+    }
 
     #[test]
     fn test_column_index_to_letters() {
@@ -86,5 +92,27 @@ mod tests {
         assert_eq!(column_index_to_letters(52), "BA");
         assert_eq!(column_index_to_letters(701), "ZZ");
         assert_eq!(column_index_to_letters(702), "AAA");
+    }
+
+    #[test]
+    fn test_detects_short_csv_without_extension() {
+        let path = temp_path("short_csv");
+        fs::write(&path, b"a,b\n").unwrap();
+
+        let detected = detect_file_type(&path).unwrap();
+        let _ = fs::remove_file(&path);
+
+        assert_eq!(detected, FileType::Csv);
+    }
+
+    #[test]
+    fn test_detects_utf8_bom_csv_without_extension() {
+        let path = temp_path("bom_csv");
+        fs::write(&path, b"\xEF\xBB\xBFna,age\nAndre,30\n").unwrap();
+
+        let detected = detect_file_type(&path).unwrap();
+        let _ = fs::remove_file(&path);
+
+        assert_eq!(detected, FileType::Csv);
     }
 }


### PR DESCRIPTION
Fixes #56\n\n## Summary\n- treat short text files without NUL bytes as CSV candidates instead of rejecting everything under 8 bytes\n- accept valid UTF-8 prefixes instead of ASCII-only prefixes so BOM-prefixed and accented headers work\n- add regression tests for short CSV and UTF-8 BOM CSV detection\n\n## Validation\n- \n- full  still fails in the existing integration suite because the checked-out repo does not include 