### PR TITLE
fix: quote CSV export headers and produce valid JSON exports (#52, #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded dependencies: `calamine` 0.34→0.35, `ratatui` 0.29→0.30, `crossterm` 0.28→0.29, `toml` 0.8→1.1
 
 ### Fixed
+- CSV export did not quote the header row ([#52](https://github.com/bgreenwell/xleak/issues/52))
+- JSON export produced invalid JSON for quotes, backslashes, newlines, and non-finite floats ([#53](https://github.com/bgreenwell/xleak/issues/53))
 - TUI search skipped most rows on lazy-loaded sheets (>1000 rows) ([#51](https://github.com/bgreenwell/xleak/issues/51))
 - Help popup (`?`) is now scrollable (↑↓/PageUp/PageDown/Home) so it stays usable on short terminals; the title shows a `[x/y]` scroll indicator
 - `display_table_data` now respects `--max-width` CLI flag instead of hardcoded 30

--- a/src/display/export.rs
+++ b/src/display/export.rs
@@ -13,15 +13,32 @@ pub(crate) fn csv_quote(value: String, delimiter: &str) -> String {
     }
 }
 
+/// Join fields into one CSV line, quoting each as needed.
+fn csv_line<I: IntoIterator<Item = String>>(fields: I, delimiter: &str) -> String {
+    fields
+        .into_iter()
+        .map(|f| csv_quote(f, delimiter))
+        .collect::<Vec<_>>()
+        .join(delimiter)
+}
+
+/// Serialize a string as a JSON string literal with full escaping.
+fn json_string(s: &str) -> String {
+    serde_json::Value::String(s.to_string()).to_string()
+}
+
 /// Serialize a cell as a JSON value (numbers/bools bare, empty as null, rest quoted).
 fn json_cell(cell: &CellValue) -> String {
     match cell {
-        CellValue::String(s) => format!("\"{}\"", s.replace('"', "\\\"")),
+        CellValue::String(s) => json_string(s),
         CellValue::Int(i) => i.to_string(),
-        CellValue::Float(f) => f.to_string(),
+        // NaN and infinities have no JSON representation; export as null.
+        CellValue::Float(f) => {
+            serde_json::Number::from_f64(*f).map_or_else(|| "null".to_string(), |n| n.to_string())
+        }
         CellValue::Bool(b) => b.to_string(),
         CellValue::Empty => "null".to_string(),
-        _ => format!("\"{cell}\""),
+        _ => json_string(&cell.to_string()),
     }
 }
 
@@ -44,27 +61,26 @@ fn print_json_rows(rows: &[Vec<CellValue>]) {
 fn print_json_string_array(items: &[String]) {
     for (i, item) in items.iter().enumerate() {
         let comma = if i < items.len() - 1 { "," } else { "" };
-        println!("    \"{item}\"{comma}");
+        println!("    {}{comma}", json_string(item));
     }
 }
 
 // ===== SheetData =====
 
 pub fn export_csv(data: &SheetData, delimiter: &str) -> Result<()> {
-    println!("{}", data.headers.join(delimiter));
+    println!("{}", csv_line(data.headers.iter().cloned(), delimiter));
     for row in &data.rows {
-        let row_str: Vec<String> = row
-            .iter()
-            .map(|cell| csv_quote(cell.to_raw_string(), delimiter))
-            .collect();
-        println!("{}", row_str.join(delimiter));
+        println!(
+            "{}",
+            csv_line(row.iter().map(|cell| cell.to_raw_string()), delimiter)
+        );
     }
     Ok(())
 }
 
 pub fn export_json(data: &SheetData, sheet_name: &str) -> Result<()> {
     println!("{{");
-    println!("  \"sheet\": \"{sheet_name}\",");
+    println!("  \"sheet\": {},", json_string(sheet_name));
     println!("  \"rows\": {},", data.height);
     println!("  \"columns\": {},", data.width);
     println!("  \"headers\": [");
@@ -90,8 +106,8 @@ pub fn export_text(data: &SheetData, delimiter: &str) -> Result<()> {
 
 pub fn export_table_json(table: &TableData) -> Result<()> {
     println!("{{");
-    println!("  \"table\": \"{}\",", table.name);
-    println!("  \"sheet\": \"{}\",", table.sheet_name);
+    println!("  \"table\": {},", json_string(&table.name));
+    println!("  \"sheet\": {},", json_string(&table.sheet_name));
     println!("  \"columns\": {},", table.headers.len());
     println!("  \"rows\": {},", table.rows.len());
     println!("  \"headers\": [");
@@ -105,13 +121,12 @@ pub fn export_table_json(table: &TableData) -> Result<()> {
 }
 
 pub fn export_table_csv(table: &TableData, delimiter: &str) -> Result<()> {
-    println!("{}", table.headers.join(delimiter));
+    println!("{}", csv_line(table.headers.iter().cloned(), delimiter));
     for row in &table.rows {
-        let row_str: Vec<String> = row
-            .iter()
-            .map(|cell| csv_quote(cell.to_raw_string(), delimiter))
-            .collect();
-        println!("{}", row_str.join(delimiter));
+        println!(
+            "{}",
+            csv_line(row.iter().map(|cell| cell.to_raw_string()), delimiter)
+        );
     }
     Ok(())
 }
@@ -123,4 +138,56 @@ pub fn export_table_text(table: &TableData, delimiter: &str) -> Result<()> {
         println!("{}", row_str.join(delimiter));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_csv_line_quotes_headers_and_fields() {
+        // #52: headers with delimiters/quotes/newlines must be quoted like data.
+        let line = csv_line(
+            vec![
+                "Name, Title".to_string(),
+                "Say \"hi\"".to_string(),
+                "plain".to_string(),
+            ],
+            ",",
+        );
+        assert_eq!(line, "\"Name, Title\",\"Say \"\"hi\"\"\",plain");
+    }
+
+    #[test]
+    fn test_csv_line_respects_custom_delimiter() {
+        let line = csv_line(vec!["a;b".to_string(), "c,d".to_string()], ";");
+        assert_eq!(line, "\"a;b\";c,d");
+    }
+
+    #[test]
+    fn test_json_string_escapes_specials() {
+        // #53: backslashes, quotes, newlines, and control chars must be escaped.
+        assert_eq!(json_string("say \"hi\""), r#""say \"hi\"""#);
+        assert_eq!(json_string("back\\slash"), r#""back\\slash""#);
+        assert_eq!(json_string("line1\nline2"), r#""line1\nline2""#);
+        assert_eq!(json_string("tab\there"), r#""tab\there""#);
+    }
+
+    #[test]
+    fn test_json_cell_values() {
+        assert_eq!(json_cell(&CellValue::Int(42)), "42");
+        assert_eq!(json_cell(&CellValue::Bool(true)), "true");
+        assert_eq!(json_cell(&CellValue::Empty), "null");
+        assert_eq!(
+            json_cell(&CellValue::String("a\\b\n\"c\"".to_string())),
+            r#""a\\b\n\"c\"""#
+        );
+    }
+
+    #[test]
+    fn test_json_cell_nonfinite_floats_are_null() {
+        assert_eq!(json_cell(&CellValue::Float(f64::NAN)), "null");
+        assert_eq!(json_cell(&CellValue::Float(f64::INFINITY)), "null");
+        assert_eq!(json_cell(&CellValue::Float(1.5)), "1.5");
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -568,3 +568,47 @@ fn test_invalid_flag_combination() {
     // clap should reject this before main runs
     assert!(!output.status.success());
 }
+
+// =========================================================================
+// Export quoting/escaping (#52, #53)
+// =========================================================================
+
+#[test]
+fn test_export_csv_quotes_headers() {
+    // #52: headers containing the delimiter or quotes must be quoted.
+    let tmpdir = std::env::temp_dir();
+    let csv_path = tmpdir.join("xleak_test_hostile_headers.csv");
+    std::fs::write(&csv_path, "\"Name, Title\",\"Say \"\"hi\"\"\"\nAlice,x\n").unwrap();
+
+    let output = run_xleak(&[csv_path.to_str().unwrap(), "--export", "csv"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let header_line = stdout.lines().next().unwrap();
+    assert_eq!(header_line, "\"Name, Title\",\"Say \"\"hi\"\"\"");
+
+    let _ = std::fs::remove_file(&csv_path);
+}
+
+#[test]
+fn test_export_json_output_is_valid_json() {
+    // #53: quotes, backslashes, and newlines in cells/headers must be escaped.
+    let tmpdir = std::env::temp_dir();
+    let csv_path = tmpdir.join("xleak_test_json_escaping.csv");
+    std::fs::write(
+        &csv_path,
+        "\"He said \"\"hi\"\"\",back\\slash\n\"multi\nline\",plain\n",
+    )
+    .unwrap();
+
+    let output = run_xleak(&[csv_path.to_str().unwrap(), "--export", "json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("export --json must produce valid JSON");
+    assert_eq!(parsed["headers"][0], "He said \"hi\"");
+    assert_eq!(parsed["headers"][1], "back\\slash");
+    assert_eq!(parsed["data"][0][0], "multi\nline");
+
+    let _ = std::fs::remove_file(&csv_path);
+}


### PR DESCRIPTION
Closes #52, closes #53.

## CSV headers unquoted (#52)

`export_csv` and `export_table_csv` joined headers raw while quoting data fields, so a header like `Name, Title` produced a malformed header row. Both now route headers through the same quoting as data via a shared `csv_line` helper.

## JSON export invalid (#53)

The hand-rolled escaping only handled double quotes, so backslashes, newlines, and control characters in cells, headers, sheet names, or table names produced invalid JSON. NaN and infinity floats also serialized as bare `NaN`/`inf` literals.

All string escaping now goes through serde_json (already a dependency), and non-finite floats export as `null`. The line-oriented output layout is unchanged.

## Tests

- Unit tests for `csv_line`, `json_string`, and `json_cell` covering delimiters, quotes, backslashes, newlines, and non-finite floats.
- Integration tests that feed hostile headers/cells through the binary: the CSV test asserts the exact quoted header line, and the JSON test parses the full output with serde_json (fails on the old code with a parse error).

Full suite passes locally: fmt, clippy (all targets, all features), 54 unit + 37 integration.
