### PR TITLE
fix: restore terminal on TUI setup failure or panic (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded dependencies: `calamine` 0.34→0.35, `ratatui` 0.29→0.30, `crossterm` 0.28→0.29, `toml` 0.8→1.1
 
 ### Fixed
+- Terminal left in raw mode when TUI setup failed or a panic unwound ([#58](https://github.com/bgreenwell/xleak/issues/58))
 - CSV export did not quote the header row ([#52](https://github.com/bgreenwell/xleak/issues/52))
 - JSON export produced invalid JSON for quotes, backslashes, newlines, and non-finite floats ([#53](https://github.com/bgreenwell/xleak/issues/53))
 - TUI search skipped most rows on lazy-loaded sheets (>1000 rows) ([#51](https://github.com/bgreenwell/xleak/issues/51))

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -201,6 +201,22 @@ impl TuiState {
     }
 }
 
+/// Undo raw mode and the alternate screen. Safe to call more than once.
+fn restore_terminal() {
+    let _ = disable_raw_mode();
+    let _ = execute!(io::stdout(), LeaveAlternateScreen, crossterm::cursor::Show);
+}
+
+/// RAII guard that restores the terminal when dropped, so early `?` returns
+/// and panic unwinds can't leave the user's shell in raw mode (#58).
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        restore_terminal();
+    }
+}
+
 /// Run the TUI application
 pub fn run_tui(
     workbook: Workbook,
@@ -220,8 +236,18 @@ pub fn run_tui(
         );
     }
 
-    // Setup terminal
+    // Restore the terminal before the panic message prints, so it lands on a
+    // readable screen instead of vanishing into the alternate buffer.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        original_hook(info);
+    }));
+
+    // Setup terminal. The guard covers every exit from here on: normal
+    // return, `?` on a failed sheet load, or a panic unwind.
     enable_raw_mode().context("Failed to enable terminal raw mode. Is this a proper TTY?")?;
+    let _guard = TerminalGuard;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).context("Failed to enter alternate screen mode")?;
     let backend = CrosstermBackend::new(stdout);
@@ -239,14 +265,7 @@ pub fn run_tui(
     )?;
 
     // Main event loop
-    let res = run_event_loop(&mut terminal, &mut app);
-
-    // Cleanup terminal
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
-
-    res
+    run_event_loop(&mut terminal, &mut app)
 }
 
 fn run_event_loop(


### PR DESCRIPTION
Closes #58.

## Problem

`run_tui` enabled raw mode and entered the alternate screen before `TuiState::new(...)?`, so a failed sheet load returned early with no cleanup. There was also no panic hook, so a panic anywhere in the event loop or render path left the shell in raw mode with the panic message swallowed by the alternate buffer.

## Fix

- A `TerminalGuard` RAII struct whose `Drop` disables raw mode, leaves the alternate screen, and shows the cursor. Created immediately after `enable_raw_mode`, it covers every exit: early `?` returns, normal quit, and panic unwinds.
- A panic hook that restores the terminal *before* delegating to the original hook, so the panic message prints on a readable screen.
- `restore_terminal` is idempotent, so guard + hook overlapping is harmless.

## Verification

Driven under a real pty (`script`) with temporary env-var hooks forcing each path, then checking `stty` in the same pty session:

- Forced setup failure after raw mode: exit 1, `stty` shows no raw flags, error message visible.
- Forced panic: the restore escapes (`[?1049l`, `[?25h`) visibly fire before the panic text, exit 101, `stty` sane.
- Normal `q` quit: unchanged, exit 0, terminal sane.

fmt/clippy clean, 54 unit + 37 integration tests pass.
