### PR TITLE
fix: strip control characters from non-interactive table output (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Terminal left in raw mode when TUI setup failed or a panic unwound ([#58](https://github.com/bgreenwell/xleak/issues/58))
+- Control characters in cells could inject terminal escape sequences via the non-interactive table view ([#59](https://github.com/bgreenwell/xleak/issues/59))
 - CSV export did not quote the header row ([#52](https://github.com/bgreenwell/xleak/issues/52))
 - JSON export produced invalid JSON for quotes, backslashes, newlines, and non-finite floats ([#53](https://github.com/bgreenwell/xleak/issues/53))
 - TUI search skipped most rows on lazy-loaded sheets (>1000 rows) ([#51](https://github.com/bgreenwell/xleak/issues/51))

--- a/src/display/sheet.rs
+++ b/src/display/sheet.rs
@@ -10,7 +10,9 @@ use std::io::IsTerminal;
 
 /// Format a cell value with width limiting. With `wrap`, the full text is
 /// returned and comfy-table wraps it; otherwise long text is truncated with "...".
+/// Control characters are stripped so file content can't inject escapes (#59).
 pub(crate) fn format_cell_value(value: &str, max_width: usize, wrap: bool) -> String {
+    let value = &*crate::utils::sanitize_terminal_text(value);
     let char_count = value.chars().count();
     if char_count <= max_width {
         return value.to_string();
@@ -43,11 +45,17 @@ pub fn display_table(
     println!();
     println!(
         "Sheet: {} ({} rows × {} columns)",
-        sheet_name, data.height, data.width
+        crate::utils::sanitize_terminal_text(sheet_name),
+        data.height,
+        data.width
     );
 
     if all_sheets.len() > 1 {
-        println!("Available sheets: {}", all_sheets.join(", "));
+        let names: Vec<_> = all_sheets
+            .iter()
+            .map(|s| crate::utils::sanitize_terminal_text(s))
+            .collect();
+        println!("Available sheets: {}", names.join(", "));
     }
 
     if !show_formulas {

--- a/src/display/table.rs
+++ b/src/display/table.rs
@@ -16,7 +16,11 @@ pub fn display_table_data(
     println!("║  xleak - Excel Table Viewer                     ║");
     println!("╚═════════════════════════════════════════════════╝");
     println!();
-    println!("Table: {} (from sheet: {})", table.name, table.sheet_name);
+    println!(
+        "Table: {} (from sheet: {})",
+        crate::utils::sanitize_terminal_text(&table.name),
+        crate::utils::sanitize_terminal_text(&table.sheet_name)
+    );
     println!(
         "{} rows × {} columns",
         table.rows.len(),
@@ -35,7 +39,8 @@ pub fn display_table_data(
 
     let mut header_row = Row::new();
     for h in &table.headers {
-        let mut cell = Cell::new(h).add_attribute(Attribute::Bold);
+        let mut cell =
+            Cell::new(crate::utils::sanitize_terminal_text(h)).add_attribute(Attribute::Bold);
         if use_color {
             cell = cell.fg(Color::Green);
         }
@@ -56,21 +61,21 @@ pub fn display_table_data(
     for row in table.rows.iter().take(rows_to_show) {
         let mut table_row = Row::new();
         for cell in row {
+            let text = cell.to_string();
+            let text = crate::utils::sanitize_terminal_text(&text);
             let cell_obj = match cell {
                 CellValue::Int(_) | CellValue::Float(_) => {
-                    Cell::new(cell.to_string()).set_alignment(CellAlignment::Right)
+                    Cell::new(text).set_alignment(CellAlignment::Right)
                 }
-                CellValue::Bool(_) => {
-                    Cell::new(cell.to_string()).set_alignment(CellAlignment::Center)
-                }
+                CellValue::Bool(_) => Cell::new(text).set_alignment(CellAlignment::Center),
                 CellValue::Error(_) => {
-                    let mut c = Cell::new(cell.to_string()).set_alignment(CellAlignment::Center);
+                    let mut c = Cell::new(text).set_alignment(CellAlignment::Center);
                     if use_color {
                         c = c.fg(Color::Red);
                     }
                     c
                 }
-                _ => Cell::new(cell.to_string()).set_alignment(CellAlignment::Left),
+                _ => Cell::new(text).set_alignment(CellAlignment::Left),
             };
             table_row.add_cell(cell_obj);
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,6 +59,18 @@ pub fn detect_file_type<P: AsRef<Path>>(path: P) -> io::Result<FileType> {
     Ok(FileType::Unknown)
 }
 
+/// Strip control characters (Unicode `Cc`: C0, DEL, C1) except tab and
+/// newline, so untrusted spreadsheet content can't inject terminal escape
+/// sequences into non-interactive output (#59). Borrows when already clean.
+pub fn sanitize_terminal_text(s: &str) -> std::borrow::Cow<'_, str> {
+    let is_bad = |c: char| c.is_control() && c != '\t' && c != '\n';
+    if s.chars().any(is_bad) {
+        std::borrow::Cow::Owned(s.chars().filter(|&c| !is_bad(c)).collect())
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
 /// Convert a zero-based column index into spreadsheet-style letters
 /// (0 -> "A", 25 -> "Z", 26 -> "AA", ...).
 pub fn column_index_to_letters(col: usize) -> String {
@@ -75,6 +87,20 @@ pub fn column_index_to_letters(col: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sanitize_terminal_text() {
+        // Escape sequences are stripped, including C1 controls.
+        assert_eq!(sanitize_terminal_text("a\x1b[31mred"), "a[31mred");
+        assert_eq!(sanitize_terminal_text("bel\x07l"), "bell");
+        assert_eq!(sanitize_terminal_text("c1\u{9b}31mx"), "c131mx");
+        // Tab and newline survive; clean strings borrow unchanged.
+        assert_eq!(sanitize_terminal_text("a\tb\nc"), "a\tb\nc");
+        assert!(matches!(
+            sanitize_terminal_text("plain"),
+            std::borrow::Cow::Borrowed("plain")
+        ));
+    }
 
     #[test]
     fn test_column_index_to_letters() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -612,3 +612,24 @@ fn test_export_json_output_is_valid_json() {
 
     let _ = std::fs::remove_file(&csv_path);
 }
+
+#[test]
+fn test_display_strips_terminal_escape_sequences() {
+    // #59: control chars in cells must not pass through to the terminal.
+    let tmpdir = std::env::temp_dir();
+    let csv_path = tmpdir.join("xleak_test_escapes.csv");
+    // Cell contains ESC ] 0 ; ... BEL (an OSC title-change sequence).
+    std::fs::write(&csv_path, "Name,Payload\nAlice,\x1b]0;pwned\x07value\n").unwrap();
+
+    let output = run_xleak(&[csv_path.to_str().unwrap(), "--no-color"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains('\x1b') && !stdout.contains('\x07'),
+        "table view must not emit raw ESC/BEL from cell contents"
+    );
+    // The printable remainder of the cell is still shown.
+    assert!(stdout.contains("value"));
+
+    let _ = std::fs::remove_file(&csv_path);
+}


### PR DESCRIPTION
Closes #59.

## Problem

The non-interactive table view printed cell contents, headers, and sheet/table names verbatim through comfy-table, so a spreadsheet cell containing ANSI or OSC escape sequences executed in the viewer's terminal (title changes, cursor manipulation, screen clearing). Since xleak's whole purpose is peeking at files you didn't author, untrusted content hitting the terminal raw is a real risk.

## Fix

New `utils::sanitize_terminal_text` strips control characters (Unicode `Cc`: C0, DEL, and C1) while keeping tab and newline, returning `Cow::Borrowed` when the string is already clean so the common case doesn't allocate. Applied at:

- `format_cell_value` in `display/sheet.rs` (covers headers and cells in the sheet view)
- sheet name and the "Available sheets" list
- headers, cells, and table/sheet names in `display/table.rs`

Deliberately not applied to exports (`--export csv/json/text`), so piped data round-trips exactly; JSON already escapes control chars as of #53. The TUI path was already safe (ratatui sanitizes).

## Tests

- Unit tests for the sanitizer (C0, BEL, C1 escapes stripped; tab/newline kept; clean strings borrow).
- Integration test feeding a literal `ESC ] 0 ; ... BEL` OSC sequence through the binary and asserting no raw ESC/BEL byte reaches stdout while printable content survives.

fmt/clippy clean, 55 unit + 38 integration tests pass.
