### PR TITLE
fix: horizontal scroll jump and extension-less UTF-8 CSV sniffing (#55, #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded dependencies: `calamine` 0.34→0.35, `ratatui` 0.29→0.30, `crossterm` 0.28→0.29, `toml` 0.8→1.1
 
 ### Fixed
+- Horizontal scroll now jumps directly after a far cursor jump instead of advancing one column per frame ([#55](https://github.com/bgreenwell/xleak/issues/55))
+- Extension-less UTF-8 CSVs (BOM or accented text) were rejected as unrecognized ([#56](https://github.com/bgreenwell/xleak/issues/56))
 - Formula display misaligned by one row with `--no-header` ([#50](https://github.com/bgreenwell/xleak/issues/50))
 - Datetimes just before midnight rendered as `24:00:00` instead of rolling to the next day ([#54](https://github.com/bgreenwell/xleak/issues/54))
 - Sheets wider than 100 columns rendered every column at zero width in interactive mode without `-H`

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,6 +55,29 @@ mod tests {
     }
 
     #[test]
+    fn test_horizontal_offset_jumps_directly() {
+        // 20 columns, each 10 wide (+1 separator), viewport 40 wide.
+        let widths = vec![10usize; 20];
+
+        // Cursor already visible: offset unchanged.
+        assert_eq!(TuiState::horizontal_offset_for(2, 0, &widths, 40), 0);
+        // Cursor left of the window: snap to it.
+        assert_eq!(TuiState::horizontal_offset_for(1, 5, &widths, 40), 1);
+        // #55: a far jump right lands in one step (columns 17..=19 fill the
+        // viewport: 3 × 11 = 33 ≤ 40), not one column per frame.
+        assert_eq!(TuiState::horizontal_offset_for(19, 0, &widths, 40), 17);
+    }
+
+    #[test]
+    fn test_horizontal_offset_overwide_column() {
+        // A column wider than the viewport becomes the only (partial) one.
+        let widths = vec![100usize; 5];
+        assert_eq!(TuiState::horizontal_offset_for(4, 0, &widths, 40), 4);
+        // Cursor past the last column: offset unchanged.
+        assert_eq!(TuiState::horizontal_offset_for(9, 3, &widths, 40), 3);
+    }
+
+    #[test]
     fn test_first_data_sheet_row() {
         // With a header row (default), the header is sheet row 1 and the first
         // data row is sheet row 2.

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -651,25 +651,57 @@ impl TuiState {
         if !self.horizontal_scroll_enabled {
             return;
         }
+        self.horizontal_scroll_offset = Self::horizontal_offset_for(
+            self.cursor_col,
+            self.horizontal_scroll_offset,
+            &self.column_widths,
+            viewport_width,
+        );
+    }
 
+    /// Compute the scroll offset that keeps `cursor_col` visible. When the
+    /// cursor is right of the visible window, jump so it becomes the rightmost
+    /// column that fits (#55: advancing one column per frame made a far jump
+    /// crawl across the screen).
+    pub(crate) fn horizontal_offset_for(
+        cursor_col: usize,
+        current_offset: usize,
+        column_widths: &[usize],
+        viewport_width: usize,
+    ) -> usize {
+        if cursor_col < current_offset {
+            return cursor_col;
+        }
+        if cursor_col >= column_widths.len() {
+            return current_offset;
+        }
+
+        // Columns visible from the current offset (last one may be partial).
         let mut total_width = 0;
-        let mut visible_end = self.horizontal_scroll_offset;
-
-        for i in self.horizontal_scroll_offset..self.column_widths.len() {
-            total_width += self.column_widths[i] + 1;
+        let mut visible_end = current_offset;
+        for (i, w) in column_widths.iter().enumerate().skip(current_offset) {
+            total_width += w + 1;
             visible_end = i + 1;
             if total_width > viewport_width {
                 break;
             }
         }
-
-        if self.cursor_col >= visible_end {
-            self.horizontal_scroll_offset += 1;
+        if cursor_col < visible_end {
+            return current_offset;
         }
 
-        if self.cursor_col < self.horizontal_scroll_offset {
-            self.horizontal_scroll_offset = self.cursor_col;
+        // Walk left from the cursor column until the viewport is full.
+        let mut used = column_widths[cursor_col] + 1;
+        let mut offset = cursor_col;
+        while offset > 0 {
+            let w = column_widths[offset - 1] + 1;
+            if used + w > viewport_width {
+                break;
+            }
+            used += w;
+            offset -= 1;
         }
+        offset
     }
 
     pub fn move_left(&mut self) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,25 +34,35 @@ pub fn detect_file_type<P: AsRef<Path>>(path: P) -> io::Result<FileType> {
     // Read the first 8 bytes (covers both the ZIP and OLE2 magic-number lengths).
     let n = file.read(&mut buffer)?;
 
-    // Too short to identify by magic number.
-    if n < 8 {
+    if n == 0 {
         return Ok(FileType::Unknown);
     }
 
     // XLSX/ZIP magic number (PK..)
-    if buffer[..4] == [0x50, 0x4B, 0x03, 0x04] {
+    if n >= 4 && buffer[..4] == [0x50, 0x4B, 0x03, 0x04] {
         return Ok(FileType::Xlsx);
     }
 
     // XLS (OLE2/CFB) magic number (D0 CF 11 E0 A1 B1 1A E1)
-    if buffer == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
+    if n == 8 && buffer == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
         return Ok(FileType::Xls);
     }
 
     // CSV is plain text with no dedicated magic number, so fall back to a
-    // heuristic: if the first 8 bytes contain no NUL (0x00) and are all ASCII,
-    // treat the file as CSV-like.
-    if buffer.iter().all(|&b| b != 0x00 && b.is_ascii()) {
+    // heuristic: NUL-free valid UTF-8 is treated as CSV-like (#56: requiring
+    // ASCII rejected BOMs and accented text; requiring 8 bytes rejected tiny
+    // files). The window may end mid-character, so a trailing incomplete
+    // sequence is fine.
+    let sample = &buffer[..n];
+    let text_like = match std::str::from_utf8(sample) {
+        Ok(s) => !s.contains('\0'),
+        Err(e) => {
+            e.error_len().is_none()
+                && e.valid_up_to() > 0
+                && !sample[..e.valid_up_to()].contains(&0)
+        }
+    };
+    if text_like {
         return Ok(FileType::Csv);
     }
 
@@ -112,5 +122,54 @@ mod tests {
         assert_eq!(column_index_to_letters(52), "BA");
         assert_eq!(column_index_to_letters(701), "ZZ");
         assert_eq!(column_index_to_letters(702), "AAA");
+    }
+
+    fn detect_tmp(name: &str, bytes: &[u8]) -> FileType {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, bytes).unwrap();
+        let result = detect_file_type(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        result
+    }
+
+    #[test]
+    fn test_detect_utf8_csv_without_extension() {
+        // #56: BOMs, accented text, and short files are CSV-like, not Unknown.
+        assert_eq!(
+            detect_tmp("xleak_sniff_bom", b"\xEF\xBB\xBFa,b\n1,2\n"),
+            FileType::Csv
+        );
+        assert_eq!(
+            detect_tmp("xleak_sniff_accent", "h\u{e9}llo,x\n".as_bytes()),
+            FileType::Csv
+        );
+        assert_eq!(detect_tmp("xleak_sniff_short", b"a,b"), FileType::Csv);
+        // 8-byte window ending mid-multibyte-character is still text.
+        assert_eq!(detect_tmp("xleak_sniff_cut", b"abcdefg\xC3"), FileType::Csv);
+    }
+
+    #[test]
+    fn test_detect_rejects_binary_and_empty() {
+        assert_eq!(detect_tmp("xleak_sniff_bin", &[0xFF; 8]), FileType::Unknown);
+        assert_eq!(
+            detect_tmp("xleak_sniff_nul", b"a,b\x00c"),
+            FileType::Unknown
+        );
+        assert_eq!(detect_tmp("xleak_sniff_empty", b""), FileType::Unknown);
+    }
+
+    #[test]
+    fn test_detect_magic_numbers() {
+        assert_eq!(
+            detect_tmp("xleak_sniff_zip", b"\x50\x4B\x03\x04rest"),
+            FileType::Xlsx
+        );
+        assert_eq!(
+            detect_tmp(
+                "xleak_sniff_ole",
+                &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]
+            ),
+            FileType::Xls
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -633,3 +633,24 @@ fn test_display_strips_terminal_escape_sequences() {
 
     let _ = std::fs::remove_file(&csv_path);
 }
+
+#[test]
+fn test_extensionless_utf8_csv_detected() {
+    // #56: a UTF-8 CSV with a BOM and no file extension must be sniffed as CSV.
+    let tmpdir = std::env::temp_dir();
+    let path = tmpdir.join("xleak_test_bom_noext");
+    let mut content = vec![0xEF, 0xBB, 0xBF];
+    content.extend_from_slice("Náme,Age\nAlice,30\n".as_bytes());
+    std::fs::write(&path, content).unwrap();
+
+    let output = run_xleak(&[path.to_str().unwrap()]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Alice"));
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
Closes #55, closes #56. The last two open items from the code audit.

## #55: horizontal scroll crawled after a far jump

`update_horizontal_scroll` only ever advanced the offset by one column per rendered frame (~10 fps with the 100ms event poll), so pressing End on a wide sheet visibly crawled across the screen for seconds. The offset computation is now extracted into `horizontal_offset_for`, a pure helper that walks back from the cursor column so it lands as the rightmost fully-visible column in a single step. Scrolling left and the already-visible cases keep their existing behavior. Unit tests cover the direct jump, the no-op cases, and a column wider than the viewport.

## #56: extension-less UTF-8 CSVs rejected

The content sniff (used only for files without a recognizing extension) required the first 8 bytes to be all ASCII and rejected files under 8 bytes, so a BOM'd or accented UTF-8 CSV got "Unrecognized file format". The text fallback now accepts NUL-free valid UTF-8, tolerating a trailing multibyte sequence cut by the 8-byte window, with no minimum size. The ZIP/OLE2 magic-number checks keep their required lengths. Unit tests cover BOM, accented, tiny, and mid-character-cut files plus binary/NUL/empty rejection; an integration test runs an extension-less BOM'd CSV through the binary end to end.

fmt/clippy clean, 65 unit + 39 integration tests pass locally.